### PR TITLE
fixed the http client slash handling and added timeout

### DIFF
--- a/src/artifactory.v401/client.go
+++ b/src/artifactory.v401/client.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"net"
+	"time"
 )
 
 type ClientConfig struct {
@@ -14,6 +16,7 @@ type ClientConfig struct {
 	VerifySSL bool
 	Client    *http.Client
 	Transport *http.Transport
+	Timeout   time.Duration
 }
 
 type ArtifactoryClient struct {
@@ -34,6 +37,12 @@ func NewClient(config *ClientConfig) (c ArtifactoryClient) {
 		config.Transport = new(http.Transport)
 	}
 	config.Transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: verifySSL()}
+	if config.Timeout != 0 {
+		config.Transport.Dial = func(network, addr string) (net.Conn, error) {
+			return net.DialTimeout(network, addr, config.Timeout)
+		}
+	}
+
 	if config.Client == nil {
 		config.Client = new(http.Client)
 	}

--- a/src/artifactory.v401/http.go
+++ b/src/artifactory.v401/http.go
@@ -41,12 +41,7 @@ func (c *ArtifactoryClient) makeRequest(method string, path string, options map[
 	for q, p := range options {
 		qs.Add(q, p)
 	}
-	var base_req_path string
-	if c.Config.BaseURL[:len(c.Config.BaseURL)-1] == "/" {
-		base_req_path = c.Config.BaseURL + path
-	} else {
-		base_req_path = c.Config.BaseURL + "/" + path
-	}
+	base_req_path := strings.TrimRight(c.Config.BaseURL, "/") + path
 	u, err := url.Parse(base_req_path)
 	if err != nil {
 		var data bytes.Buffer

--- a/src/artifactory.v401/http_test.go
+++ b/src/artifactory.v401/http_test.go
@@ -1,1 +1,46 @@
 package artifactory
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"net/http"
+	"go.riotgames.com/telemetry-engineering/germes-utils/Godeps/_workspace/src/github.com/stretchr/testify/assert"
+)
+
+func TestHTTP(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, r.URL.String(), "http://127.0.0.1:8080/test/url/here", "Request string should be http://127.0.0.1:8080/test/url/here, but was: " + r.URL.String())
+		        w.WriteHeader(200)
+			w.Write([]byte("{}"))
+		}))
+	defer server.Close()
+
+	transport := &http.Transport{
+		        Proxy: func(req *http.Request) (*url.URL, error) {
+			                return url.Parse(server.URL)
+			        },
+		}
+
+	conf := &ClientConfig{
+		        BaseURL:   "http://127.0.0.1:8080/",
+		        Username:  "username",
+		        Password:  "password",
+		        VerifySSL: false,
+		        Transport: transport,
+		}
+
+	client := NewClient(conf)
+
+	//Address ends with slash
+	_, err := client.Get("/test/url/here", make(map[string]string))
+	assert.NoError(t, err, "should not return an error")
+
+
+	conf.BaseURL = "http://127.0.0.1:8080"
+	client = NewClient(conf)
+
+	//Address ends with no Slash
+	_, err = client.Get("/test/url/here", make(map[string]string))
+	assert.NoError(t, err, "should not return an error")
+}


### PR DESCRIPTION
All the path parameters on all files start with a slash, 
some examples: 
search.go ln17: url := "/api/search/gavc"
groups.go ln37: d, e := c.Get("/api/security/groups/" ...
but the logic http.go ln44 to 49 always adds an extra slash. 

Added a test to check this case, and fixed the issue. 

Also added an optional timeout parameter to the clientConfig
