### PR TITLE
removing unnecessary check in users library

### DIFF
--- a/artifactory.v54/users.go
+++ b/artifactory.v54/users.go
@@ -2,7 +2,6 @@ package artifactory
 
 import (
 	"encoding/json"
-	"errors"
 )
 
 // User represents a user in artifactory
@@ -49,9 +48,6 @@ func (c *Client) GetUserDetails(key string, q map[string]string) (UserDetails, e
 
 // CreateUser creates a user with the specified details
 func (c *Client) CreateUser(key string, u UserDetails, q map[string]string) error {
-	if u.Email == "" || u.Password == "" {
-		return errors.New("Email and password are required to create users")
-	}
 	j, err := json.Marshal(u)
 	if err != nil {
 		return err


### PR DESCRIPTION
I want to remove this from the 5.4 for a couple reasons. The first being, IMO this check doesn't belong in the library. It should be up to the user to set these kind of checks, not something we do for them in the library. Also it actually prevents a valid use case for the library. Let me give an example. If someone has Artifactory hooked up to LDAP, then when you create the user you don't actually have to specify the password. But our library would actually prevent the creation of the user since the password wasn't specified.