### PR TITLE
Update client

### DIFF
--- a/artifactory.v54/client_test.go
+++ b/artifactory.v54/client_test.go
@@ -55,7 +55,8 @@ func TestClientFromEnvWithBasicAuth(t *testing.T) {
 	os.Setenv("ARTIFACTORY_USERNAME", "admin")                    //nolint
 	os.Setenv("ARTIFACTORY_PASSWORD", "password")                 //nolint
 	os.Setenv("ARTIFACTORY_TOKEN", "")                            //nolint
-	client := NewClientFromEnv()
+	client, err := NewClientFromEnv()
+	assert.Nil(t, err)
 	assert.NotNil(t, client)
 	assert.Equal(t, "http://artifactory.server.com", client.Config.BaseURL)
 	assert.Equal(t, "basic", client.Config.AuthMethod)
@@ -66,8 +67,9 @@ func TestClientFromEnvWithBasicAuth(t *testing.T) {
 func TestClientFromEnvWithTokenAuth(t *testing.T) {
 	os.Setenv("ARTIFACTORY_URL", "http://artifactory.server.com") //nolint
 	os.Setenv("ARTIFACTORY_TOKEN", "someToken")                   //nolint
-	client := NewClientFromEnv()
+	client, err := NewClientFromEnv()
 	assert.NotNil(t, client)
+	assert.Nil(t, err)
 	assert.Equal(t, "http://artifactory.server.com", client.Config.BaseURL)
 	assert.Equal(t, "token", client.Config.AuthMethod)
 	assert.Equal(t, "someToken", client.Config.Token)

--- a/script/build
+++ b/script/build
@@ -1,2 +1,3 @@
 #!/bin/bash
-go build ./artifactory.v51
+
+go build ./artifactory.v51 ./artifactory.v54

--- a/script/coverage
+++ b/script/coverage
@@ -1,5 +1,6 @@
 #!/bin/bash
 go get github.com/axw/gocov/gocov
 
-
 gocov test ./artifactory.v51 | gocov report
+
+gocov test ./artifactory.v54 | gocov report

--- a/script/test
+++ b/script/test
@@ -1,2 +1,2 @@
 #!/bin/bash
-go test -v ./artifactory.v51
+go test -v ./artifactory.v51 ./artifactory.v54


### PR DESCRIPTION
Updating the client to return an err instead of calling os.Exit. This will make the client more user friendly to those who are looking to use the package as a library.