### PR TITLE
Fixed typos in json unmarshalling

### DIFF
--- a/artifactory.v54/groups.go
+++ b/artifactory.v54/groups.go
@@ -4,14 +4,14 @@ import (
 	"encoding/json"
 )
 
-// Group represents the json response for a group in Artifactory
-type Group struct {
+// GroupShort represents the json response for a list of groups in Artifactory
+type GroupShort struct {
 	Name string `json:"name"`
 	URI  string `json:"uri"`
 }
 
-// GroupDetails represents the json response for a group's details in artifactory
-type GroupDetails struct {
+// Group represents the json response for a group in artifactory
+type Group struct {
 	Name            string `json:"name,omitempty"`
 	Description     string `json:"description,omitempty"`
 	AutoJoin        bool   `json:"autoJoin,omitempty"`
@@ -20,9 +20,8 @@ type GroupDetails struct {
 	RealmAttributes string `json:"realmAttributes,omitempty"`
 }
 
-// GetGroups gets a list of groups from artifactory
-func (c *Client) GetGroups() ([]Group, error) {
-	var res []Group
+func (c *Client) GetGroups() ([]GroupShort, error) {
+	var res []GroupShort
 	d, err := c.Get("/api/security/groups", make(map[string]string))
 	if err != nil {
 		return res, err
@@ -31,9 +30,8 @@ func (c *Client) GetGroups() ([]Group, error) {
 	return res, err
 }
 
-// GetGroupDetails returns details for a Group
-func (c *Client) GetGroupDetails(key string, q map[string]string) (GroupDetails, error) {
-	var res GroupDetails
+func (c *Client) GetGroup(key string, q map[string]string) (Group, error) {
+	var res Group
 	d, err := c.Get("/api/security/groups/"+key, q)
 	if err != nil {
 		return res, err
@@ -42,12 +40,24 @@ func (c *Client) GetGroupDetails(key string, q map[string]string) (GroupDetails,
 	return res, err
 }
 
-// CreateGroup creates a group in artifactory
-func (c *Client) CreateGroup(key string, g GroupDetails, q map[string]string) error {
+func (c *Client) CreateGroup(key string, g Group, q map[string]string) error {
 	j, err := json.Marshal(g)
 	if err != nil {
 		return err
 	}
 	_, err = c.Put("/api/security/groups/"+key, j, q)
+	return err
+}
+
+func (c *Client) UpdateGroup(key string, g Group, q map[string]string) error {
+	j, err := json.Marshal(g)
+	if err != nil {
+		return err
+	}
+	_, err = c.Post("/api/security/groups/"+key, j, q)
+	return err
+}
+func (c *Client) DeleteGroup(key string) error {
+	err := c.Delete("/api/security/groups/"+key)
 	return err
 }

--- a/artifactory.v54/groups_test.go
+++ b/artifactory.v54/groups_test.go
@@ -83,7 +83,7 @@ func TestGetGroupDetails(t *testing.T) {
 	}
 
 	client := NewClient(conf)
-	group, err := client.GetGroupDetails("docker-readers", make(map[string]string))
+	group, err := client.GetGroup("docker-readers", make(map[string]string))
 	assert.NoError(t, err, "should not return an error")
 	assert.Equal(t, group.Name, "docker-readers", "name should be docker-readers")
 	assert.Equal(t, group.Description, "Can read from Docker repositories", "description should match")
@@ -117,7 +117,7 @@ func TestCreateGroupNoDetails(t *testing.T) {
 	}
 
 	client := NewClient(conf)
-	var details = GroupDetails{}
+	var details = Group{}
 	err := client.CreateGroup("testgroup", details, make(map[string]string))
 	assert.NoError(t, err, "should not return an error")
 	assert.Equal(t, "{}", buf.String(), "should send empty json")
@@ -150,7 +150,7 @@ func TestCreateGroupDetails(t *testing.T) {
 
 	client := NewClient(conf)
 
-	details := GroupDetails{
+	details := Group{
 		Name:            "docker-readers",
 		Description:     "Can read from Docker repositories",
 		AutoJoin:        false,

--- a/artifactory.v54/repos.go
+++ b/artifactory.v54/repos.go
@@ -75,11 +75,11 @@ type RemoteRepoConfig struct {
 	StoreArtifactsLocally             bool   `json:"storeArtifactsLocally,omitempty"`
 	SocketTimeoutMillis               int    `json:"socketTimeoutMillis,omitempty"`
 	LocalAddress                      string `json:"localAddress,omitempty"`
-	RetrivialCachePeriodSecs          int    `json:"retrievalCachePeriodSecs,omitempty"`
+	RetrievalCachePeriodSecs          int    `json:"retrievalCachePeriodSecs,omitempty"`
 	FailedRetrievalCachePeriodSecs    int    `json:"failedRetrievalCachePeriodSecs,omitempty"`
 	MissedRetrievalCachePeriodSecs    int    `json:"missedRetrievalCachePeriodSecs,omitempty"`
-	UnusedArtifactsCleanupEnabled     bool   `json:"unusedArtifactCleanupEnabled,omitempty"`
-	UnusedArtifactsCleanupPeriodHours int    `json:"unusedArtifactCleanupPeriodHours,omitempty"`
+	UnusedArtifactsCleanupEnabled     bool   `json:"unusedArtifactsCleanupEnabled,omitempty"`
+	UnusedArtifactsCleanupPeriodHours int    `json:"unusedArtifactsCleanupPeriodHours,omitempty"`
 	FetchJarsEagerly                  bool   `json:"fetchJarsEagerly,omitempty"`
 	FetchSourcesEagerly               bool   `json:"fetchSourcesEagerly,omitempty"`
 	ShareConfiguration                bool   `json:"shareConfiguration,omitempty"`

--- a/artifactory.v54/repos_test.go
+++ b/artifactory.v54/repos_test.go
@@ -168,7 +168,7 @@ func TestGetRepositoryWithRemoteRepoConfig(t *testing.T) {
 	assert.Equal(t, true, repo.(RemoteRepoConfig).StoreArtifactsLocally, "Repo store artifacts locally should be true")
 	assert.Equal(t, 15000, repo.(RemoteRepoConfig).SocketTimeoutMillis, "Repo socket timeout millis should be 15000")
 	assert.Equal(t, "", repo.(RemoteRepoConfig).LocalAddress, "Repo local address should be empty")
-	assert.Equal(t, 43200, repo.(RemoteRepoConfig).RetrivialCachePeriodSecs, "Repo retrieval cache period secs should be 43200")
+	assert.Equal(t, 43200, repo.(RemoteRepoConfig).RetrievalCachePeriodSecs, "Repo retrieval cache period secs should be 43200")
 	assert.Equal(t, 7200, repo.(RemoteRepoConfig).FailedRetrievalCachePeriodSecs, "Repo failed retrieval cache period secs should be 7200")
 	assert.Equal(t, 7200, repo.(RemoteRepoConfig).MissedRetrievalCachePeriodSecs, "Repo missed retrieval cache period secs should be 7200")
 	assert.Equal(t, false, repo.(RemoteRepoConfig).UnusedArtifactsCleanupEnabled, "Repo unused artifact cleanup enabled should be false")

--- a/artifactory.v54/users.go
+++ b/artifactory.v54/users.go
@@ -5,13 +5,13 @@ import (
 )
 
 // User represents a user in artifactory
-type User struct {
+type UserShort struct {
 	Name string `json:"name"`
 	URI  string `json:"uri"`
 }
 
-// UserDetails represents the details of a user in artifactory
-type UserDetails struct {
+// User represents the details of a user in artifactory
+type User struct {
 	Name                     string   `json:"name,omitempty"`
 	Email                    string   `json:"email"`
 	Password                 string   `json:"password"`
@@ -24,9 +24,8 @@ type UserDetails struct {
 	Groups                   []string `json:"groups,omitempty"`
 }
 
-// GetUsers returns all users
-func (c *Client) GetUsers() ([]User, error) {
-	var res []User
+func (c *Client) GetUsers() ([]UserShort, error) {
+	var res []UserShort
 	d, err := c.Get("/api/security/users", make(map[string]string))
 	if err != nil {
 		return res, err
@@ -35,19 +34,7 @@ func (c *Client) GetUsers() ([]User, error) {
 	return res, err
 }
 
-// GetUserDetails returns details for the named user
-func (c *Client) GetUserDetails(key string, q map[string]string) (UserDetails, error) {
-	var res UserDetails
-	d, err := c.Get("/api/security/users/"+key, q)
-	if err != nil {
-		return res, err
-	}
-	err = json.Unmarshal(d, &res)
-	return res, err
-}
-
-// CreateUser creates a user with the specified details
-func (c *Client) CreateUser(key string, u UserDetails, q map[string]string) error {
+func (c *Client) CreateUser(key string, u User, q map[string]string) error {
 	j, err := json.Marshal(u)
 	if err != nil {
 		return err
@@ -56,14 +43,27 @@ func (c *Client) CreateUser(key string, u UserDetails, q map[string]string) erro
 	return err
 }
 
-// DeleteUser deletes a user
-func (c *Client) DeleteUser(key string) error {
-	err := c.Delete("/api/security/users/" + key)
+func (c *Client) GetUser(key string, q map[string]string) (User, error) {
+	var res User
+	d, err := c.Get("/api/security/users/"+key, q)
+	if err != nil {
+		return res, err
+	}
+	err = json.Unmarshal(d, &res)
+	return res, err
+}
+
+
+func (c *Client) UpdateUser(key string, u User, q map[string]string) error {
+	j, err := json.Marshal(u)
+	if err != nil {
+		return err
+	}
+	_, err = c.Post("/api/security/users/"+key, j, q)
 	return err
 }
 
-// GetUserEncryptedPassword returns the current user's encrypted password
-func (c *Client) GetUserEncryptedPassword() (string, error) {
-	d, err := c.Get("/api/security/encryptedPassword", make(map[string]string))
-	return string(d), err
+func (c *Client) DeleteUser(key string) error {
+	err := c.Delete("/api/security/users/" + key)
+	return err
 }

--- a/artifactory.v54/users_test.go
+++ b/artifactory.v54/users_test.go
@@ -77,7 +77,7 @@ func TestGetUserDetails(t *testing.T) {
 	}
 
 	client := NewClient(conf)
-	user, err := client.GetUserDetails("admin", make(map[string]string))
+	user, err := client.GetUser("admin", make(map[string]string))
 	assert.NoError(t, err, "should not return an error")
 	assert.Equal(t, user.Name, "admin", "name should be admin")
 	assert.Equal(t, user.Email, "admin@admin.com", "should have email of admin@admin.com")
@@ -117,7 +117,7 @@ func TestCreateUser(t *testing.T) {
 
 	client := NewClient(conf)
 
-	user := UserDetails{
+	user := User{
 		Name:                     "admin",
 		Email:                    "test@test.com",
 		Password:                 "somepass",
@@ -145,7 +145,7 @@ func TestCreateUserFailure(t *testing.T) {
 	}
 
 	client := NewClient(conf)
-	var details = UserDetails{}
+	var details = User{}
 	err := client.CreateUser("testuser", details, make(map[string]string))
 	assert.Error(t, err, "should return an error")
 }
@@ -175,32 +175,4 @@ func TestDeleteUser(t *testing.T) {
 	client := NewClient(conf)
 	err := client.DeleteUser("testuser")
 	assert.NoError(t, err, "should not return an error")
-}
-
-func TestGetUserEncryptedPassword(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
-		w.Header().Set("Content-Type", "text/plain")
-		fmt.Fprintf(w, "ABCDEFGH")
-	}))
-	defer server.Close()
-
-	transport := &http.Transport{
-		Proxy: func(req *http.Request) (*url.URL, error) {
-			return url.Parse(server.URL)
-		},
-	}
-
-	conf := &ClientConfig{
-		BaseURL:   "http://127.0.0.1:8080/",
-		Username:  "username",
-		Password:  "password",
-		VerifySSL: false,
-		Transport: transport,
-	}
-
-	client := NewClient(conf)
-	d, err := client.GetUserEncryptedPassword()
-	assert.NoError(t, err, "should not return an error")
-	assert.Equal(t, d, "ABCDEFGH", "encrypted password should be returned")
 }


### PR DESCRIPTION
The JSON typos prevent unmarshalling of both of those fields. The typo in the field would be breaking and may need to be reviewed. 

